### PR TITLE
Add document folder overviews

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+Thanks for your interest in helping with *Lineage: Ancestral Legacies*! This project follows a simple workflow to keep the history tidy and collaboration smooth.
+
+## Workflow
+
+1. **Branching**: Create feature branches from `main` using a descriptive name such as `feature/camera-zoom` or `bugfix/navmesh`.
+2. **Commit messages**: Use short present‑tense summaries (e.g. `Add zoom controls`). Group related changes in a single commit when possible.
+3. **Pull requests**: Open a pull request describing the changes and reference related documents or issues. After review, merge back to `main`.
+
+## Code Style
+
+- Follow the existing C# conventions used in `Assets/Scripts`.
+- Keep documentation in Markdown (`.md`) where possible and place new docs inside the appropriate folder under `Documents/`.
+- Before committing, ensure the project opens in Unity without errors.
+
+Happy coding!

--- a/Documents/01_Design/README.md
+++ b/Documents/01_Design/README.md
@@ -1,0 +1,14 @@
+# Design Documents
+
+This folder collects game design plans and prototypes. Key areas include:
+
+- **01_Core** – central design philosophies and core gameplay loops
+- **02_Mechanics** – descriptions of individual game mechanics
+- **03_Story** – lore notes and narrative planning
+- **04_Ideas** – miscellaneous brainstorming and concept notes
+- **05_Systems** – technical systems and feature specifications
+- **06_Roadmap** – high-level development milestones
+- **07_Tasks** – design team tasks and to-do lists
+- **08_Debug** – debugging notes and investigation logs
+- **09_Changelog** – major design revisions over time
+- **10_Concept Art** – reference art and sketches

--- a/Documents/02_Tasks/README.md
+++ b/Documents/02_Tasks/README.md
@@ -1,0 +1,4 @@
+# Task Planning
+
+Contains task lists and optimization plans. Files here outline migration work,
+technical debt cleanup and other to-dos for upcoming milestones.

--- a/Documents/03_Research/README.md
+++ b/Documents/03_Research/README.md
@@ -1,0 +1,4 @@
+# Research
+
+Background material and references used during development. Examples include
+historical context, gameplay analysis and inspirational sources.

--- a/Documents/04_Guides/Onboarding_Developer_Guide.md
+++ b/Documents/04_Guides/Onboarding_Developer_Guide.md
@@ -1,0 +1,21 @@
+# Developer Onboarding Guide
+
+Welcome to the project! This short guide explains how to set up the Unity environment and points you to key resources in the repository.
+
+## Unity Setup
+
+1. Install the Unity version listed in `ProjectSettings/ProjectVersion.txt`.
+2. Use Unity Hub to add the project by selecting the repository folder.
+3. After Unity finishes importing, open the `Lineage` scene or any sample scene to confirm the project loads correctly.
+
+## Where to Find Information
+
+- **Design documents** – `Documents/01_Design`
+- **Research** – `Documents/03_Research`
+- **Guides and how‑tos** – `Documents/04_Guides`
+
+These folders contain gameplay concepts, system plans and practical setup guides.
+
+## Next Steps
+
+Familiarize yourself with the `Assets` directory and explore the scripts and StudioTools infrastructure. When you are ready to contribute, read `CONTRIBUTING.md` for the workflow.

--- a/Documents/04_Guides/README.md
+++ b/Documents/04_Guides/README.md
@@ -1,0 +1,4 @@
+# Guides
+
+Step-by-step instructions and how-tos for team members. Here you'll find
+camera configuration tips, tool usage notes and onboarding references.

--- a/Documents/07_Legal/README.md
+++ b/Documents/07_Legal/README.md
@@ -1,0 +1,3 @@
+# Legal
+
+Licensing information and any legal disclaimers related to the project.

--- a/Documents/08_Git/README.md
+++ b/Documents/08_Git/README.md
@@ -1,0 +1,4 @@
+# Git Notes
+
+Notes about version control. The `01_Merge Descriptions` folder contains short
+write-ups explaining merges for historical reference.

--- a/Documents/README.md
+++ b/Documents/README.md
@@ -1,0 +1,11 @@
+# Documentation Overview
+
+This directory stores design documents, research material and workflow guides.
+Below is a summary of each subfolder:
+
+- **01_Design/** – High level and detailed design documents
+- **02_Tasks/** – Project task lists and optimization plans
+- **03_Research/** – Reference material used in development
+- **04_Guides/** – How-to documents and onboarding guides
+- **07_Legal/** – Legal notes and license references
+- **08_Git/** – Version control notes and merge descriptions

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Lineage: Ancestral Legacies
+
+This repository contains the Unity project for *Lineage: Ancestral Legacies*, an RTS and survival game focused on guiding early human tribes. The repo mixes source code, project settings and an extensive set of design documents.
+
+## Repository Layout
+
+- **Assets/** – Game assets, C# scripts and editor tools
+- **Documents/** – Design documents, research notes and guides
+- **Packages/** – Package manifests for Unity
+- **ProjectSettings/** – Unity project configuration
+
+### Documents Overview
+
+The repository contains extensive planning material under `Documents/`:
+
+- **01_Design** – Game design documents and concept art
+- **02_Tasks** – Pending work items and optimization plans
+- **03_Research** – Reference material used during development
+- **04_Guides** – How-to guides and onboarding docs
+- **07_Legal** – Licensing notes and legal documentation
+- **08_Git** – Version-control notes and merge descriptions
+
+See `Documents/README.md` for more details.
+
+## Getting Started
+
+1. Install the Unity version specified in `ProjectSettings/ProjectVersion.txt`.
+2. Open the project through the Unity Hub by choosing the repository folder.
+3. Review the guides inside `Documents/04_Guides` for configuration and workflow tips.
+
+Contributions are welcome! See `CONTRIBUTING.md` for workflow guidelines.


### PR DESCRIPTION
## Summary
- expand README with document folder list
- create Documentation README describing subfolders
- add short README pages inside each Documents folder

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6841cf5f3e4083328b42617eebc7b856